### PR TITLE
feat: integrate renew token from the backend

### DIFF
--- a/app/src/main/java/com/bangkit/android/dermatify/data/remote/response/AuthResponse.kt
+++ b/app/src/main/java/com/bangkit/android/dermatify/data/remote/response/AuthResponse.kt
@@ -13,6 +13,11 @@ data class LogoutResponse(
     val message: String
 )
 
+data class RenewResponse(
+    val message: String,
+    val accessToken: String
+)
+
 data class ErrorResponse(
     val statusCode: Int,
     val error: String,

--- a/app/src/main/java/com/bangkit/android/dermatify/data/remote/retrofit/ApiService.kt
+++ b/app/src/main/java/com/bangkit/android/dermatify/data/remote/retrofit/ApiService.kt
@@ -3,6 +3,7 @@ package com.bangkit.android.dermatify.data.remote.retrofit
 import com.bangkit.android.dermatify.data.remote.response.LoginResponse
 import com.bangkit.android.dermatify.data.remote.response.LogoutResponse
 import com.bangkit.android.dermatify.data.remote.response.RegisterResponse
+import com.bangkit.android.dermatify.data.remote.response.RenewResponse
 import retrofit2.http.Field
 import retrofit2.http.FormUrlEncoded
 import retrofit2.http.POST
@@ -29,4 +30,11 @@ interface ApiService {
         @Field("email") email: String,
         @Field("accessToken") accessToken: String
     ): LogoutResponse
+
+    @FormUrlEncoded
+    @POST("auth/renew")
+    suspend fun renewAccessToken(
+        @Field("email") email: String,
+        @Field("refreshToken") refreshToken: String
+    ): RenewResponse
 }

--- a/app/src/main/java/com/bangkit/android/dermatify/ui/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/bangkit/android/dermatify/ui/profile/ProfileViewModel.kt
@@ -20,6 +20,7 @@ class ProfileViewModel(private val userRepository: UserRepository) : ViewModel()
 
     fun logout() = userRepository.logout()
 
+    fun renewAccessToken() = userRepository.renewAccessToken()
 
 
 }


### PR DESCRIPTION
when access token is invalid during login session, then the app tries to renew user's access token and if the refresh token is invalid or user is not found then navigate to onboarding (automatically logout the account)